### PR TITLE
TS-17964 Update base image to use maven jdk 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-8
+FROM maven:3.8.3-openjdk-17
 
 RUN \
     apt-get update && \


### PR DESCRIPTION
After updating eop-installer to use source and target 11 and trying to build it locally, I got an error "invalid release target 11". I realized this is because we're building EOP on a docker image, and the docker image only has jdk 8.

This PR updates that docker image to use a JDK 17 base image. https://hub.docker.com/layers/library/maven/3.8.3-openjdk-17/images/sha256-9c31c89f38703a5ebe23741eb1760d88f9224b9fb5cf5e596df5549237cefd6a?context=repo&tab=vulnerabilities

How to test?
- Using this updated Docker image, and using the EOP branches that are updated to use java 11 (all 3 branches are called `TS-17964`), build eop with `./local_build_eop_docker`. The build should succeed

I haven't actually tested this because I'm not sure how to. If I merge this PR and get a new image deployed to `ghcr.io/contrast-security-oss/contrast/maven-install4j:latest` then I know I can test it that way. This is only used for building EOP locally.