### PR TITLE
TS-17964 Update Dockerfile to use jdk17 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM maven:3.8.3-openjdk-17
 
 RUN \
-    apt-get update && \
-    apt-get install -y nano && \
-    apt-get install -y zip && \
-    wget https://download-gcdn.ej-technologies.com/install4j/install4j_linux_8_0_7.deb && \
-    dpkg -i install4j_linux_8_0_7.deb && \
-    rm install4j_linux_8_0_7.deb
+    microdnf install -y nano && \
+    microdnf install -y zip && \
+    microdnf install -y wget && \
+    microdnf install -y rpm && \
+    microdnf install xdg-utils && \
+    wget https://download.ej-technologies.com/install4j/install4j_linux_8_0_11.rpm && \
+    rpm -ivh install4j_linux_8_0_11.rpm && \
+    rm install4j_linux_8_0_11.rpm

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Dockerfile which builds an image containing maven and install4j build tools
 Always remember to [update the latest tag](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#tagging-container-images) after uploading a new release:
 
 ```shell
+# Build the container locally
+docker build -t maven-install4j .
+
+# Get the IMAGE ID of the newly created image
+docker images
+
+# Log into Docker using a github token with write_packages
+docker login ghcr.io -u github_username -p ghp_mygithubtokenxxxxxxxxxx
+
 # Update tag locally
 docker tag $imageID ghcr.io/contrast-security-oss/contrast/maven-install4j
 


### PR DESCRIPTION
TODO
- [ ] Investigate building locally without Docker. If that works fine, then we don't need this image anymore, and instead of updating it, we can delete it and its repository

This is to update the docker image we use to build eop with `local_build_eop_docker`. The extant  version of this image uses jdk8, but we need one with at least JDK 11 (I'm going with JDK 17) so that we can build EOP when it's using a newer java version. Right now I'm getting it onto Java 11, but soon we'll want to compile it with Java 17.

I merged this PR earlier, but it didn't actually work. I updated the base image but needed to make more changes than just that: https://github.com/Contrast-Security-OSS/maven-install4j-docker/pull/3/files

The new base image is based off of oraclelinux:8-slim which uses Fedora instead of Debian. So I have to use dnf (actually `microdnf` which is a bit smaller for the slim image), and have to use the `.rpm` packages instead of the `.deb` package. Also found I needed the xdg utils.

Now I've tested it locally and can start the container and install all this stuff. I'm still a little concerned the slim container might lead to problems when actually trying to build eop-installer in it, because that will require a fair amount of space. But I don't know how to test that yet.

After merging this, I need to build a new container and upload it to ghcr. Currently I'm getting a permission error when trying to do that. And then once it's up in ghcr we should be able to use it to build EOP locally with java 11+


How to test?
- Download and run the base image, open a shell
```
docker run -it oraclelinux:8-slim /bin/bash
```
- Run the contents of the Dockerfile
```
RUN \
    microdnf install -y nano && \
    microdnf install -y zip && \
    microdnf install -y wget && \
    microdnf install -y rpm && \
    microdnf install xdg-utils && \
    wget https://download.ej-technologies.com/install4j/install4j_linux_8_0_11.rpm && \
    rpm -ivh install4j_linux_8_0_11.rpm && \
    rm install4j_linux_8_0_11.rpm
```
- It should complete without errors